### PR TITLE
Fixed 4 issues of type: PYTHON_E402 throughout 2 files in repo.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,6 +22,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+from neutron_taas_dashboard \
+    import version as ui_ver
 from __future__ import print_function
 
 import os
@@ -37,8 +39,6 @@ sys.path.insert(0, ROOT)
 os.environ.setdefault('DJANGO_SETTINGS_MODULE',
                       'neutron_taas_dashboard.test.settings')
 
-from neutron_taas_dashboard \
-    import version as ui_ver
 
 
 def write_autodoc_index():

--- a/neutron_taas_dashboard/test/settings.py
+++ b/neutron_taas_dashboard/test/settings.py
@@ -11,6 +11,9 @@
 #    under the License.
 
 # Default to Horizons test settings to avoid any missing keys
+import neutron_taas_dashboard.enabled
+import openstack_dashboard.enabled
+from openstack_dashboard.utils import settings
 from horizon.test.settings import *  # noqa
 from openstack_dashboard.test.settings import *  # noqa
 
@@ -20,9 +23,6 @@ HORIZON_CONFIG.pop('dashboards', None)
 HORIZON_CONFIG.pop('default_dashboard', None)
 
 # Update the dashboards with neutron_taas_dashboard
-import neutron_taas_dashboard.enabled
-import openstack_dashboard.enabled
-from openstack_dashboard.utils import settings
 
 settings.update_dashboards(
     [


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.